### PR TITLE
Fix problems with modals/dialogs by adding delay to Observer

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -75,7 +75,10 @@ export const VAceEditor = defineComponent({
       }
     });
     this._ro = new ResizeObserver(() => editor.resize());
-    this._ro.observe(this.$el);
+    setTimeout(() => {
+      // Start observing with a short delay to prevent problems with modals/dialogs
+      this._ro.observe(this.$el);
+    }, 300)
     this.$emit('init', editor);
   },
   beforeUnmount(this: VAceEditorInstance) {


### PR DESCRIPTION
I had a quite unique problem.

When loading Ace editor inside of a dialog/modal (like Quasar Framework Dialog), the dialog would be opening for 15 seconds (while blocking everything else).

Then I realized the observer is the root cause of this.

When I added a short delay before starting the observer the problem went away and dialog opens instantly.