### PR TITLE
Export VAceEditorInstance

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,8 @@ import ResizeObserver from 'resize-observer-polyfill';
 
 import type { VAceEditorInstance } from './types';
 
+export type VAceEditorInstance;
+
 const Events = [
   'blur',
   'input',

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import ResizeObserver from 'resize-observer-polyfill';
 
 import type { VAceEditorInstance } from './types';
 
-export type VAceEditorInstance;
+export { type VAceEditorInstance } from './types';
 
 const Events = [
   'blur',


### PR DESCRIPTION
Export the `VAceEditorInstance` type from the package. Now you can have type checking when using TypeScript:
```typescript
import type { VAceEditorInstance } from 'vue3-ace-editor';

const editor = ref<VAceEditorInstance>();
```
